### PR TITLE
Update gutenberg commit hash expection on iOS Podfile

### DIFF
--- a/org/ios.ts
+++ b/org/ios.ts
@@ -14,7 +14,7 @@ export default async () => {
     const podfileContents = await danger.github.utils.fileContents("Podfile");
     const matches = podfileContents.match(/^[^#]*:commit/gm);
     if (matches !== null) {
-        const nonGutenbergMatches = matches.filter(m => !m.includes("wordpress-mobile/gutenberg"));
+        const nonGutenbergMatches = matches.filter(m => !m.includes("gutenberg"));
         if (nonGutenbergMatches.length > 0) {
             fail("Podfile: reference to a commit hash");
         }


### PR DESCRIPTION
I made a change on the WPiOS Podfile to simplify handling gutenberg references.
Those changes broke the gutenberg exception.

This is how the Podfile looks:
https://github.com/wordpress-mobile/WordPress-iOS/blob/cbed6c40bed0e1bfc3f1de918cfb81d008512ea4/Podfile#L104

If this is not the best way and is better to bring back the `:git => ...` reference to that line, please let me now and I'll do that. Otherwise I hope the change in this PR will fix the gutenberg `:commit => ...` exception.
