### PR TITLE
Make release notes checks work with .po and .pot files

### DIFF
--- a/org/android.ts
+++ b/org/android.ts
@@ -4,7 +4,7 @@ export default async () => {
 
     // If changes were made to the release notes, there must also be changes to the PlayStoreStrings file.
     const hasModifiedReleaseNotes = danger.git.modified_files.some(f => f.endsWith("metadata/release_notes.txt"));
-    const hasModifiedPlayStoreStrings = danger.git.modified_files.some(f => f.endsWith("metadata/PlayStoreStrings.po"));
+    const hasModifiedPlayStoreStrings = danger.git.modified_files.some(f => f.includes("metadata/PlayStoreStrings.po"));
 
     if (hasModifiedReleaseNotes && !hasModifiedPlayStoreStrings) {
         warn("The PlayStoreStrings.po file must be updated any time changes are made to release notes");

--- a/org/ios.ts
+++ b/org/ios.ts
@@ -22,7 +22,7 @@ export default async () => {
 
     // If changes were made to the release notes, there must also be changes to the AppStoreStrings file.
     const hasModifiedReleaseNotes = danger.git.modified_files.some(f => f.endsWith("Resources/release_notes.txt"));
-    const hasModifiedAppStoreStrings = danger.git.modified_files.some(f => f.endsWith("Resources/AppStoreStrings.po"));
+    const hasModifiedAppStoreStrings = danger.git.modified_files.some(f => f.includes("Resources/AppStoreStrings.po"));
 
     if (hasModifiedReleaseNotes && !hasModifiedAppStoreStrings) {
         warn("The AppStoreStrings.po file must be updated any time changes are made to release notes");


### PR DESCRIPTION
I noticed that the release notes check fails on the WooCommerce apps because they use .pot files instead of .po. 

I'm also not sure how we can test it. 